### PR TITLE
Working

### DIFF
--- a/PublishScript_macOS.sh
+++ b/PublishScript_macOS.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+dotnet publish WooriOptical/WooriOptical.csproj -c Release --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o ./backend
+echo "Backend published to ./backend"
+cp ./WooriOptical/WooriOptical.db ./backend
+cp -R ./backend ../WooriOptical.Electron/backend
+echo "Backend copied to ../WooriOptical.Electron/backend"
+
+cd WooriOptical.Electron
+
+npm install
+echo "Node modules installed"
+npm run make
+echo "app packaged at /WooriOptical.Electron/out"

--- a/WooriOptical.Electron/main.js
+++ b/WooriOptical.Electron/main.js
@@ -1,7 +1,52 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, dialog } = require('electron');
 const { spawn } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 let backend;
+
+function getBackendPath() {
+  console.log('app.isPackaged=', app.isPackaged, 'platform=', process.platform, 'NODE_ENV=', process.env.NODE_ENV);
+
+  // candidates to try (ordered)
+  const candidates = [];
+
+  if (app.isPackaged) {
+    // packaged app: Resources folder
+    candidates.push(path.join(process.resourcesPath, 'backend', 'WooriOptical'));
+    // electron-builder may put extras in app.asar.unpacked
+    candidates.push(path.join(process.resourcesPath, 'app.asar.unpacked', 'backend', 'WooriOptical'));
+    // sometimes people put extras directly in Resources
+    candidates.push(path.join(process.resourcesPath, 'WooriOptical'));
+  } else {
+    // development — be permissive: try several dev locations
+    candidates.push(path.join(__dirname, 'backend', 'WooriOptical'));
+    candidates.push(path.join(__dirname, '..', 'backend', 'WooriOptical'));
+    candidates.push(path.join(process.cwd(), 'backend', 'WooriOptical'));
+  }
+
+  // Also accept .exe or .dll variants (Windows dev builds or dotnet DLL)
+  const variants = [];
+  for (const c of candidates) {
+    variants.push(c);
+    variants.push(c + '.exe');
+    variants.push(c + '.dll');
+  }
+
+  for (const p of variants) {
+    try {
+      if (fs.existsSync(p)) {
+        console.log('Found backend candidate:', p);
+        return p;
+      }
+    } catch (err) {
+      console.warn('existsSync failed for', p, err);
+    }
+  }
+
+  // nothing found — return null to allow caller to handle
+  console.error('Backend executable not found. Tried:', variants);
+  return null;
+}
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -13,31 +58,61 @@ function createWindow() {
     }
   });
   win.setMenuBarVisibility(false);
-  win.loadURL('http://localhost:5000');
-}
-
-function getBackendPath() {
-  if (app.isPackaged) {
-    // In packaged app, extraResources are in a different location
-    return path.join(process.resourcesPath, 'backend', 'WooriOptical.exe');
-  } else {
-    // In development
-    return path.join(__dirname, 'backend', 'WooriOptical.exe');
-  }
+  win.loadURL('http://127.0.0.1:5000');
 }
 
 app.whenReady().then(() => {
   const backendPath = getBackendPath();
 
-  backend = spawn(backendPath, [], {
-    cwd: path.dirname(backendPath),
-    env: { 
-      ...process.env, 
-      ASPNETCORE_URLS: 'http://localhost:5000' 
-    }
-  });
+  if (!backendPath) {
+    const msg = 'Backend binary not found. Make sure you published/copy the backend into Resources/backend or app.asar.unpacked/backend.';
+    console.error(msg);
+    dialog.showErrorBox('Backend not found', msg);
+    createWindow(); // still open UI so user can see error
+    return;
+  }
 
-  // Wait for backend to start
+  // If we found a .dll, run with 'dotnet'
+  const isDll = backendPath.endsWith('.dll');
+  const isExe = fs.existsSync(backendPath) && fs.statSync(backendPath).mode & 0o111; // check exec bit
+
+  // If file exists but isn't executable on macOS, try to set +x (best-effort)
+  if (process.platform === 'darwin' && !isDll) {
+    try {
+      fs.chmodSync(backendPath, 0o755);
+    } catch (err) {
+      console.warn('Could not chmod backend (permission?), continuing:', err.message);
+    }
+  }
+
+  let spawnCmd, spawnArgs;
+  if (isDll) {
+    spawnCmd = 'dotnet';
+    spawnArgs = [backendPath];
+  } else {
+    spawnCmd = backendPath;
+    spawnArgs = [];
+  }
+
+  try {
+    backend = spawn(spawnCmd, spawnArgs, {
+      cwd: path.dirname(backendPath),
+      env: {
+        ...process.env,
+        ASPNETCORE_URLS: 'http://127.0.0.1:5000'
+      },
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    backend.stdout.on('data', d => console.log('[backend]', d.toString()));
+    backend.stderr.on('data', d => console.error('[backend]', d.toString()));
+    backend.on('exit', (code, sig) => console.log('Backend exited', code, sig));
+  } catch (err) {
+    console.error('Failed to spawn backend:', err);
+    dialog.showErrorBox('Failed to start backend', String(err));
+  }
+
+  // wait for backend (simple delay); prefer polling HTTP for production
   setTimeout(createWindow, 3000);
 });
 

--- a/WooriOptical.Electron/package-lock.json
+++ b/WooriOptical.Electron/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "woorioptical",
       "version": "1.0.0",
+      "dependencies": {
+        "@electron-forge/cli": "^7.8.3"
+      },
       "devDependencies": {
         "@electron-forge/cli": "^7.8.3",
         "@electron-forge/maker-deb": "^7.8.3",

--- a/WooriOptical.Electron/package-lock.json
+++ b/WooriOptical.Electron/package-lock.json
@@ -428,7 +428,7 @@
     "node_modules/@electron/node-gyp": {
       "version": "10.2.0-electron.1",
       "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-4MSBTT8y07YUDqf69/vSh80Hh791epYqGtWHO3zSKhYFwQg+gx9wi1PqbqP6YqC4WMsNxZ5l9oDmnWdK5pfCKQ==",
+      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/WooriOptical.Electron/package.json
+++ b/WooriOptical.Electron/package.json
@@ -42,5 +42,8 @@
         }
       ]
     }
+  },
+  "dependencies": {
+    "@electron-forge/cli": "^7.8.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -428,7 +428,7 @@
     "node_modules/@electron/node-gyp": {
       "version": "10.2.0-electron.1",
       "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-4MSBTT8y07YUDqf69/vSh80Hh791epYqGtWHO3zSKhYFwQg+gx9wi1PqbqP6YqC4WMsNxZ5l9oDmnWdK5pfCKQ==",
+      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This pull request improves the build and startup process for the Electron-based app by introducing a macOS publishing script, enhancing backend binary detection and startup logic in the Electron main process, and updating package dependencies. These changes make the app more robust and easier to build and run across different environments.

**Build and packaging improvements:**

* Added a new `PublishScript_macOS.sh` script to automate publishing the .NET backend, copying necessary files, installing Node modules, and packaging the Electron app for macOS.

**Electron backend startup robustness:**

* Refactored backend binary detection in `main.js` to handle various deployment and development scenarios, including support for `.exe`, `.dll`, and native binaries, and improved error handling when the backend is missing.
* Enhanced backend process spawning logic to support running `.dll` files via `dotnet`, ensure executability on macOS, and log backend output for easier debugging.
* Changed frontend to load from `http://127.0.0.1:5000` instead of `localhost` for consistency with backend binding.

**Dependency updates:**

* Added `@electron-forge/cli` to both `dependencies` and `devDependencies` in `package.json` and `package-lock.json` to ensure consistent packaging tools are available. [[1]](diffhunk://#diff-7ac98afdcd84d7782254f7ce14dd2192b631d6e729e425b97d6f02aea1cb0a42R10-R12) [[2]](diffhunk://#diff-fb701428c984858877fb824d84fd5d3330c885f7873ef2318d48903aa6c64777R45-R47)
* Updated the integrity hash for `@electron/node-gyp` in `package-lock.json` for dependency consistency.